### PR TITLE
Show last 30 days of predictions

### DIFF
--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -67,11 +67,16 @@ Future<List<PredictionData>> loadHistoricalData(String metricShortName) async {
   final metricId = await getMetricId(metricShortName);
   if (metricId == null) return [];
 
-  // Join na models a metrics, vyfiltruj podle metric_id
+  // Datum 30 dní zpět
+  final thirtyDaysAgo =
+      DateTime.now().subtract(const Duration(days: 30)).toIso8601String().split('T')[0];
+
+  // Join na models a metrics, vyfiltruj podle metric_id a posledních 30 dní
   final response = await supabase
       .from('predictions')
       .select('date, probability, metrics(short_name), models(name)')
       .eq('metric_id', metricId)
+      .gte('date', thirtyDaysAgo)
       .order('date', ascending: true);
 
   return (response as List)

--- a/lib/widgets/prediction_graph.dart
+++ b/lib/widgets/prediction_graph.dart
@@ -16,13 +16,13 @@ class PredictionGraph extends StatelessWidget {
       return const Center(child: Text('No data available', style: TextStyle(color: Colors.white70)));
     }
 
-    // Group data by model for multi-line graph
+    // Group data by model for multi-line graph and map X axis to days
     Map<String, List<FlSpot>> modelData = {};
+    final startDate = data.first.date;
     for (var entry in data) {
       modelData.putIfAbsent(entry.model, () => []);
-      modelData[entry.model]!.add(
-        FlSpot(data.indexOf(entry).toDouble(), entry.probability),
-      );
+      final days = entry.date.difference(startDate).inDays.toDouble();
+      modelData[entry.model]!.add(FlSpot(days, entry.probability));
     }
 
     return LineChart(
@@ -40,13 +40,15 @@ class PredictionGraph extends StatelessWidget {
           bottomTitles: AxisTitles(
             sideTitles: SideTitles(
               showTitles: true,
+              interval: 5,
               reservedSize: 32,
               getTitlesWidget: (value, meta) {
-                final index = value.toInt();
-                if (index >= 0 && index < data.length) {
-                  return Text(data[index].date.toString().substring(0, 10), style: const TextStyle(color: Colors.white70, fontSize: 10));
-                }
-                return const Text('');
+                if (value < 0) return const Text('');
+                final date = startDate.add(Duration(days: value.toInt()));
+                return Text(
+                  date.toString().substring(5, 10),
+                  style: const TextStyle(color: Colors.white70, fontSize: 10),
+                );
               },
             ),
           ),
@@ -62,7 +64,7 @@ class PredictionGraph extends StatelessWidget {
         ),
         borderData: FlBorderData(show: false),
         minX: 0,
-        maxX: data.length - 1.toDouble(),
+        maxX: data.last.date.difference(startDate).inDays.toDouble(),
         minY: 0,
         maxY: 100,
         lineBarsData: modelData.entries.map((entry) {


### PR DESCRIPTION
## Summary
- limit Supabase query to last 30 days
- map graph's X-axis to days
- show date labels and clamp maxX by date range

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688583cbfb04832e9860fb9734eff811